### PR TITLE
Fixes the notion api response parsing

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -1,9 +1,11 @@
 """Description of your app."""
 from typing import Type
-from steamship.invocable import Config, create_handler, post, PackageService
+
+from steamship.invocable import Config, PackageService, create_handler, post
 
 # NOTE: It should be `notion` not `src.notion` here.
-from notion import notion_get, add_markdown
+from notion import add_markdown, notion_page_to_audio_url
+
 # NOTE: It should be `transcribe` not `src.transcribe` here.
 from transcribe import transcribe_audio
 
@@ -30,18 +32,7 @@ class NotionAutoTranscribe(PackageService):
         This uses the API Key provided at configuration time to fetch the Notion Page, transcribe the
         attached audio file, and then post the transcription results back to Notion as Markdown Text.
         """
-
-        # Parse the Block ID from the Notion URL
-        block_id = url.split("#")[1]
-
-        # Get the Notion page
-        print(f"Getting notion block {block_id}")
-        notion_page = notion_get(f"blocks/{block_id}", self.config.notion_key)
-
-        # Get the Page ID and Audio URL from the Notion File JSON
-        audio_url = notion_page['audio']['file']['url']
-        page_id = notion_page['parent']['page_id']
-
+        page_id, audio_url = notion_page_to_audio_url(url, self.config.notion_key)
         print(f"Audio url: {audio_url}")
         print(f"Page ID: {page_id}")
 
@@ -56,5 +47,6 @@ class NotionAutoTranscribe(PackageService):
         print(f"Res JSON: {res_json}")
 
         return res_json
+
 
 handler = create_handler(NotionAutoTranscribe)

--- a/src/notion.py
+++ b/src/notion.py
@@ -1,17 +1,23 @@
+"""Helper functions for Notion."""
+import json
+import uuid
 from typing import Dict
 
 import requests
-import json
+
 
 def notion_headers(api_key: str) -> dict:
+    """Prepare notion api headers."""
     return {
-        'authorization': f"Bearer {api_key}",
-        'Content-Type': 'application/json',
-        'Notion-Version': '2022-06-28',
+        "authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Notion-Version": "2022-06-28",
         "accept": "application/json",
     }
 
+
 def notion_get(path: str, api_key: str):
+    """Send a notion get request."""
     url = f"https://api.notion.com/v1/{path}"
     response = requests.get(url, headers=notion_headers(api_key))
     print(response.text)
@@ -19,26 +25,66 @@ def notion_get(path: str, api_key: str):
     print(res_json)
     return res_json
 
+
 def notion_patch(path: str, content: Dict, api_key: str):
+    """Send a notion patch request."""
     url = f"https://api.notion.com/v1/{path}"
     response = requests.patch(url, json=content, headers=notion_headers(api_key))
     res_json = response.json()
     return res_json
 
+
+PageId = str
+AudioUrl = str
+
+
+def notion_block_to_audio_url(block: dict) -> (PageId, AudioUrl):
+    """Get the audio url from the notion block json."""
+    audio_url = block["audio"]["file"]["url"]
+    page_id = block["parent"]["page_id"]
+    return (page_id, audio_url)
+
+
+def notion_page_to_audio_url(url: str, api_key: str) -> (PageId, AudioUrl):
+    """Get the audio url from the notion page url."""
+    if "#" in url:
+        # We assume someone has copied the block.
+        block_id = url.split("#")[1]
+        block = notion_get(f"blocks/{block_id}", api_key)
+        return notion_block_to_audio_url(block)
+    else:
+        # This is what the incoming Zapier page reference will look like.
+        # from: https://www.notion.so/Creating-Page-Sample-ee18b8779ae54f358b09221d6665ee15
+        # to: Creating-Page-Sample-ee18b8779ae54f358b09221d6665ee15
+        block_id = url.split("/")[-1]
+        # from: Creating-Page-Sample-ee18b8779ae54f358b09221d6665ee15
+        # to: ee18b8779ae54f358b09221d6665ee15
+        block_id = block_id.split("-")[-1]
+
+        # This is necessary because the URL doesn't have the hyphens in 8-4-4-4-12 format, but the API requires it
+        block_uuid = uuid.UUID(block_id)
+        notion_page_children = notion_get(f"blocks/{block_uuid}/children", api_key)
+        return notion_block_to_audio_url(notion_page_children["results"][0])
+
+
 def add_markdown(page_id: str, markdown: str, api_key: str):
+    """Add markdown to the page."""
     add_text_block = {
-        "children":
-            [{
+        "children": [
+            {
                 "object": "block",
                 "type": "paragraph",
                 "paragraph": {
-                    "rich_text": [{
-                        "type": "text",
-                        "text": {
-                            "content": markdown,
+                    "rich_text": [
+                        {
+                            "type": "text",
+                            "text": {
+                                "content": markdown,
+                            },
                         }
-                    }]
-                }
-            }]
+                    ]
+                },
+            }
+        ]
     }
     return notion_patch(f"blocks/{page_id}/children", add_text_block, api_key)

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
   "type": "package",
-  "handle": "notion-auto-transcribe",
-  "version": "1.1.5",
+  "handle": "notion-auto-transcribe-ted",
+  "version": "1.1.7",
   "description": "",
   "author": "",
   "entrypoint": "api.handler",

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
   "type": "package",
-  "handle": "notion-auto-transcribe-ted",
-  "version": "1.1.7",
+  "handle": "notion-auto-transcribe",
+  "version": "1.1.8",
   "description": "",
   "author": "",
   "entrypoint": "api.handler",

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2,24 +2,37 @@
 import os
 from pathlib import Path
 
+from dotenv import load_dotenv
 from steamship import Steamship
 
+from notion import notion_page_to_audio_url
 from src.api import NotionAutoTranscribe
 
-from dotenv import load_dotenv
-
-env_path = Path('.') / '.env'
+env_path = Path(".") / ".env"
 load_dotenv(dotenv_path=env_path)
+
+
+def test_transcription_page():
+    """Tests that we're getting the audio url correctly."""
+    env_path = Path(".") / ".env"
+    load_dotenv(dotenv_path=env_path)
+    NOTION_KEY = os.environ.get("NOTION_KEY")
+    url = "https://www.notion.so/Mind-stack-057b827f994f4ef2ac0e18777e197efb"
+    page_id, audio_url = notion_page_to_audio_url(url, NOTION_KEY)
+    assert page_id
+    assert audio_url
 
 
 def test_transcription():
     """You can test your app like a regular Python object."""
     print("Running")
     client = Steamship()
-    env_path = Path('.') / '.env'
+    env_path = Path(".") / ".env"
     load_dotenv(dotenv_path=env_path)
     NOTION_KEY = os.environ.get("NOTION_KEY")
 
     app = NotionAutoTranscribe(client=client, config={"notion_key": NOTION_KEY})
 
-    app.transcribe(url="https://www.notion.so/69f267134bd44249817339cad1a2e140#6575059dc4f14ead922e8e09f0afee6b")
+    app.transcribe(
+        url="https://www.notion.so/69f267134bd44249817339cad1a2e140#6575059dc4f14ead922e8e09f0afee6b"
+    )


### PR DESCRIPTION
Before the parsing assumed the URL was a Notion Block URL.

The Notion database API delivers, instead, the URL to the notion page itself.

This update should handle either case.